### PR TITLE
fix cgroups v2 for judge0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       start_period: 10s
 
   judge0_server:
-    image: judge0/judge0:1.13.1
+    image: mrkushalsm/judge0:cgv2
 
     env_file: ./judge0.conf
     container_name: judge0_server
@@ -77,7 +77,7 @@ services:
       start_period: 10s
   
   judge0_worker:
-    image: judge0/judge0:1.13.1
+    image: mrkushalsm/judge0:cgv2
     container_name: judge0_worker
     command: ["./scripts/workers"]
     volumes:


### PR DESCRIPTION
Исправление образа для работы проверки в judge0, потому по умолчанию требуется cgroups v1 на хосте 
