### PR TITLE
Feature/issue 114 add limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,6 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=password
 DATABASE_URL=postgresql://postgres:password@postgresdb_data:5432/course_database
 
-# Frontend
-FRONTEND_PORT=80
-
 # Logs
 LOG_MAX_SIZE=100M
 LOG_MAX_FILE=3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# Надо сделать для прода: везде ограничение по ресурсам, мониторинг и сеть, резервное копирование дб
-# В проде убрать имена контейнеров
 version: '3.8'
 
 x-logging:
@@ -11,6 +9,15 @@ x-logging:
       max-file: ${LOG_MAX_FILE:-3}
       compress: "${LOG_COMPRESS:-true}"
 
+x-resource-limits:
+  &default-limits
+  resources:
+    limits:
+      cpus: '1.0'
+      memory: 1G
+    reservations:
+      cpus: '0.5'
+      memory: 512M
 
 services:
   postgresdb:
@@ -29,6 +36,14 @@ services:
       timeout: 10s
       retries: 5
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   redis:
     image: redis:7.2.4
@@ -48,6 +63,14 @@ services:
       timeout: 10s
       retries: 5
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   judge0_server:
     image: mrkushalsm/judge0:cgv2
@@ -74,6 +97,14 @@ services:
       timeout: 10s
       retries: 5
       start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 512M
   
   judge0_worker:
     image: mrkushalsm/judge0:cgv2
@@ -99,7 +130,16 @@ services:
       timeout: 10s
       retries: 5
       start_period: 10s
-
+    deploy:
+      mode: replicated
+      replicas: 2  # Для 10-20 студентов. Для большего количества увеличить
+      resources:
+        limits:
+          cpus: '0.8'
+          memory: 768M
+        reservations:
+          cpus: '0.4'
+          memory: 384M
 
   postgresdb_data:
     image: postgres:17-alpine
@@ -117,6 +157,14 @@ services:
       retries: 5
     networks:
       - app-net
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   backend:
     image: mse1h2026-judge0-lti_backend-python-fastapi:v.0.4
@@ -142,11 +190,14 @@ services:
       start_period: 10s
     networks:
       - app-net
-    # deploy:
-    #   resources:
-    #     limits:
-    #       cpus: '1'
-    #       memory: 1024M
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
 
   frontend:
     image: mse1h2026-judge0-lti_frontend-nginx-react:v.0.4
@@ -159,7 +210,7 @@ services:
     env_file:
       - .env
     ports:
-      - "80:${FRONTEND_PORT}"
+      - "80:80"
     depends_on:
       backend:
         condition: service_healthy
@@ -171,6 +222,14 @@ services:
       start_period: 10s
     networks:
       - app-net
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ x-resource-limits:
 services:
   postgresdb:
     image: postgres:17-alpine
-    container_name: mse1h2026-judge0-lti_postgresql-judge0
+    #container_name: mse1h2026-judge0-lti_postgresql-judge0
     env_file: ./judge0.conf
     volumes:
       - postgres-data-judge0:/var/lib/postgresql/data/
@@ -47,7 +47,7 @@ services:
 
   redis:
     image: redis:7.2.4
-    container_name: mse1h2026-judge0-lti_redis
+    #container_name: mse1h2026-judge0-lti_redis
     command: [
       "bash", "-c",
       'docker-entrypoint.sh --appendonly no --requirepass "$$REDIS_PASSWORD"'
@@ -76,7 +76,7 @@ services:
     image: mrkushalsm/judge0:cgv2
 
     env_file: ./judge0.conf
-    container_name: mse1h2026-judge0-lti_judge0-server
+    #container_name: mse1h2026-judge0-lti_judge0-server
     volumes:
       - ./judge0.conf:/judge0.conf:ro
     ports:
@@ -108,7 +108,7 @@ services:
   
   judge0_worker:
     image: mrkushalsm/judge0:cgv2
-    container_name: mse1h2026-judge0-lti_judge0-worker
+    #container_name: mse1h2026-judge0-lti_judge0-worker
     command: ["./scripts/workers"]
     volumes:
       - ./judge0.conf:/judge0.conf:ro
@@ -143,7 +143,7 @@ services:
 
   postgresdb_data:
     image: postgres:17-alpine
-    container_name: mse1h2026-judge0-lti_postgresdb-data
+    #container_name: mse1h2026-judge0-lti_postgresdb-data
     restart: unless-stopped
     <<: *default-logging
     env_file: 
@@ -172,7 +172,7 @@ services:
       context: ./backend
       dockerfile: Dockerfile
       target: prod
-    container_name: backend-python-fastapi # mse1h2026-judge0-lti_backend-python-fastapi для этого надо поменять nginx.conf
+    container_name: backend-python-fastapi # чтобы убрать надо поменять nginx.conf
     restart: unless-stopped
     <<: *default-logging
     env_file:
@@ -204,7 +204,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    container_name: mse1h2026-judge0-lti_frontend-nginx-react
+    #container_name: mse1h2026-judge0-lti_frontend-nginx-react
     restart: unless-stopped
     <<: *default-logging
     env_file:


### PR DESCRIPTION
## Требования к ресурсам

Расчёт основан на **оптимизированной проверке**: все тесты задачи отправляются в Judge0 одним запросом.  
Пик – максимальное количество студентов, одновременно нажимающих «Проверить» (например, во время контрольной).  
Для задачи принято 5 тестов. При другом количестве пересчитайте пропорционально.

### 1. Сводная таблица минимальных ресурсов (оптимизированный вариант)

| Сценарий | Кол-во студентов | Пик проверок | CPU (ядер) | RAM (ГБ) | Диск (ГБ SSD) | Сеть (Мбит/с) |
|----------|----------------|--------------|------------|----------|---------------|----------------|
| Тестовый | 1              | 1            | 1          | 2        | 20            | 10             |
| Малая группа | 10         | 5            | 3          | 4        | 50            | 50             |
| Активный курс | 100       | 20           | 7          | 8        | 200           | 200            |
| Массовый курс | 500       | 100          | 24         | 32       | 700           | 500            |

### 2. Детальный расчёт по компонентам (оптимизированный вариант)

Базовые допущения:
- 1 worker Judge0 обрабатывает 1 проверку за раз (все тесты вместе).
- Время одной проверки ≈ 1.5 секунды (5 тестов × 0.3 сек).
- RAM на worker Judge0: 150 МБ (реалистично).
- CPU на worker Judge0: 0.3 ядра (эффективность за счёт асинхронности).
- RAM на backend (одна реплика FastAPI): 150 МБ.
- PostgreSQL: базово 512 МБ + 50 МБ на каждые 10 активных сессий.

#### Сценарий 1 студент (пик 1 проверка)

| Компонент | Реплики | CPU (ядра) | RAM (МБ) | Диск (ГБ) |
|-----------|---------|------------|----------|-----------|
| backend   | 1       | 0.3        | 150      | 1         |
| frontend  | 1       | 0.1        | 128      | 0.5       |
| postgres_data | 1   | 0.2        | 512      | 10        |
| judge0_server | 1   | 0.2        | 512      | 1         |
| redis     | 1       | 0.1        | 128      | 0.2       |
| postgres_judge0 | 1 | 0.1       | 256      | 2         |
| judge0_worker | 1   | 0.3        | 150      | 0.5       |
| **Итого** |         | **1.3**    | **~1.8 ГБ** | **15** |

#### Сценарий 10 студентов (пик 5 проверок)

| Компонент | Реплики | CPU (ядра) | RAM (МБ) | Диск (ГБ) |
|-----------|---------|------------|----------|-----------|
| backend   | 1       | 0.5        | 300      | 2         |
| frontend  | 1       | 0.2        | 256      | 1         |
| postgres_data | 1   | 0.3        | 768      | 30        |
| judge0_server | 1   | 0.3        | 768      | 2         |
| redis     | 1       | 0.2        | 256      | 0.5       |
| postgres_judge0 | 1 | 0.2       | 384      | 5         |
| judge0_worker | 3 (потому что 5 проверок в очереди с 3 workers дают приемлемую задержку) | 3×0.3=0.9 | 3×150=450 | 3×0.5=1.5 |
| **Итого** |         | **2.6**    | **~3.2 ГБ** | **42** |

#### Сценарий 100 студентов (пик 20 проверок)

| Компонент | Реплики | CPU (ядра) | RAM (МБ) | Диск (ГБ) |
|-----------|---------|------------|----------|-----------|
| backend   | 2       | 2×0.5=1.0  | 2×300=600 | 10 |
| frontend  | 1       | 0.5        | 512      | 2         |
| postgres_data | 1   | 1.0        | 2048     | 200       |
| judge0_server | 1   | 0.5        | 1024     | 5         |
| redis     | 1       | 0.3        | 512      | 1         |
| postgres_judge0 | 1 | 0.3       | 768      | 20        |
| judge0_worker | 10 (20 проверок / 2 = 10 workers с учётом очереди) | 10×0.3=3.0 | 10×150=1500 | 10×0.5=5 |
| **Итого** |         | **6.6**    | **~7 ГБ** | **243** |

#### Сценарий 500 студентов (пик 100 проверок)

| Компонент | Реплики | CPU (ядра) | RAM (ГБ) | Диск (ГБ) |
|-----------|---------|------------|----------|-----------|
| backend   | 5       | 5×0.5=2.5  | 5×0.3=1.5 | 20 |
| frontend  | 1       | 1.0        | 1        | 5         |
| postgres_data* | 1 | 4.0        | 8        | 500       |
| judge0_server | 1 | 1.0        | 2        | 10        |
| redis     | 1       | 0.5        | 1        | 2         |
| postgres_judge0 | 1 | 0.5       | 1        | 50        |
| judge0_worker | 50 (100 проверок / 2) | 50×0.3=15 | 50×0.15=7.5 | 50×0.5=25 |
| **Итого** |         | **24.5**   | **~22 ГБ** | **612**   |

\* Для 500 студентов рекомендуется выделенный сервер БД или управляемый кластер.

### 3. Сравнение с неоптимизированной архитектурой (отдельный запрос на тест)

При текущей реализации (цикл по тестам, каждый тест — отдельный запрос к Judge0) нагрузка возрастает в `(количество тестов)` раз. При 5 тестах множитель = 5.

| Пик проверок | Оптимизированный вариант (CPU worker / RAM worker) | Неоптимизированный вариант (CPU worker / RAM worker) |
|--------------|-----------------------------------------------------|-------------------------------------------------------|
| 1            | 1.3 ядра / 1.8 ГБ                                  | 6.5 ядра / 9 ГБ                                    |
| 5            | 2.6 ядра / 3.2 ГБ                                  | 13 ядра / 16 ГБ                                    |
| 20           | 6.6 ядра / 7 ГБ                                   | 33 ядер / 38 ГБ                                      |
| 100          | 25 ядер / 24 ГБ                                    | 125 ядер / 120 ГБ                                     |

### 4. Примечания

- Для более оптимального использования ресурсов требуется изменить реализацию проверки и передавать все тесты а worker, а не по одному.
- **Пик** – максимальное количество студентов, одновременно отправляющих решение. Обычно составляет 20-30% от общего числа (например, при экзамене из 100 студентов могут проверять 20 одновременно).
- **CPU** – суммарное количество физических ядер (hyper-threading даёт прирост не более 30%). Для 100 студентов достаточно 6 ядер, для 500 – 24 ядра.
- **RAM** – указана с учётом работы всех сервисов и запаса на кэш БД. Для больших нагрузок PostgreSQL может потребовать до 16-32 ГБ.
- **Диск** – обязательно SSD. Объём зависит от количества попыток и решений. На 100 студентов за семестр может накопиться 50-100 ГБ данных; указано с запасом.
- **Сеть** – основной трафик – передача кода и результатов (единицы КБ на проверку). Пиковое потребление не превышает 10-20 Мбит/с на 100 проверок, но указан запас для статики и одновременного доступа к интерфейсу.